### PR TITLE
Include version.txt in the source distribution

### DIFF
--- a/fiftyone_pipeline_cloudrequestengine/MANIFEST.in
+++ b/fiftyone_pipeline_cloudrequestengine/MANIFEST.in
@@ -1,0 +1,1 @@
+include version.txt

--- a/fiftyone_pipeline_core/MANIFEST.in
+++ b/fiftyone_pipeline_core/MANIFEST.in
@@ -1,1 +1,2 @@
 include fiftyone_pipeline_core/JavaScriptResource.mustache
+include version.txt

--- a/fiftyone_pipeline_engines/MANIFEST.in
+++ b/fiftyone_pipeline_engines/MANIFEST.in
@@ -1,0 +1,1 @@
+include version.txt

--- a/fiftyone_pipeline_engines_fiftyone/MANIFEST.in
+++ b/fiftyone_pipeline_engines_fiftyone/MANIFEST.in
@@ -1,0 +1,1 @@
+include version.txt


### PR DESCRIPTION
Otherwise the package will get installed as version 0.0.0, because setup.py wouldn't be able to find the correct version.