### PR TITLE
Add tox pre-publish configs

### DIFF
--- a/fiftyone_pipeline_cloudrequestengine/tox.ini
+++ b/fiftyone_pipeline_cloudrequestengine/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-;envlist = py{37,38,39,310,311,312}
 minversion = 4.0
 
 [testenv]
@@ -12,9 +11,12 @@ deps =
     parameterized
 commands =
     pytest --cov=. --import-mode=append {tty:--color=yes} {posargs}
-;    pytest --cov=. {tty:--color=yes} {posargs}
-;    - coverage combine
-;    - coverage xml
 pass_env =
     resource_key
     license_key
+
+[testenv:pre-publish]
+package = skip
+deps =
+    {[testenv]deps}
+    -r ../../package/pre-publish-requirements.txt

--- a/fiftyone_pipeline_core/tox.ini
+++ b/fiftyone_pipeline_core/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-;envlist = py{37,38,39,310,311,312}
 minversion = 4.0
 
 [testenv]
@@ -14,9 +13,12 @@ deps =
     flask
 commands =
     pytest --cov=. --import-mode=append {tty:--color=yes} {posargs}
-;    pytest --cov=. {tty:--color=yes} {posargs}
-;    - coverage combine
-;    - coverage xml
 pass_env =
     resource_key
     license_key
+
+[testenv:pre-publish]
+package = skip
+deps =
+    {[testenv]deps}
+    -r ../../package/pre-publish-requirements.txt

--- a/fiftyone_pipeline_engines/tox.ini
+++ b/fiftyone_pipeline_engines/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-;envlist = py{37,38,39,310,311,312}
 minversion = 4.0
 
 [testenv]
@@ -11,9 +10,12 @@ deps =
     pytest-cov
 commands =
     pytest --cov=. --import-mode=append {tty:--color=yes} {posargs}
-;    pytest --cov=. {tty:--color=yes} {posargs}
-;    - coverage combine
-;    - coverage xml
 pass_env =
     resource_key
     license_key
+
+[testenv:pre-publish]
+package = skip
+deps =
+    {[testenv]deps}
+    -r ../../package/pre-publish-requirements.txt

--- a/fiftyone_pipeline_engines_fiftyone/tox.ini
+++ b/fiftyone_pipeline_engines_fiftyone/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-;envlist = py{37,38,39,310,311,312}
 minversion = 4.0
 
 [testenv]
@@ -12,9 +11,12 @@ deps =
     flask
 commands =
     pytest --cov=. --import-mode=append {tty:--color=yes} {posargs}
-;    pytest --cov=. {tty:--color=yes} {posargs}
-;    - coverage combine
-;    - coverage xml
 pass_env =
     resource_key
     license_key
+
+[testenv:pre-publish]
+package = skip
+deps =
+    {[testenv]deps}
+    -r ../../package/pre-publish-requirements.txt


### PR DESCRIPTION
These configs will be used during `publish` pipeline to enable use of prebuilt packages