### PR TITLE
Specify build system in `pyproject.toml`

### DIFF
--- a/fiftyone_pipeline_cloudrequestengine/pyproject.toml
+++ b/fiftyone_pipeline_cloudrequestengine/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/fiftyone_pipeline_core/pyproject.toml
+++ b/fiftyone_pipeline_core/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/fiftyone_pipeline_engines/pyproject.toml
+++ b/fiftyone_pipeline_engines/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/fiftyone_pipeline_engines_fiftyone/pyproject.toml
+++ b/fiftyone_pipeline_engines_fiftyone/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Added `pyproject.toml` file(s) with specified build system to fulfil modern standards ([PEP 517](https://peps.python.org/pep-0517/), [PEP 518](https://peps.python.org/pep-0518/))
We've also added [`build` frontend](https://pypi.org/project/build/) to our CI/CD, we should be able to ship `wheel`s alongside source distribution