### PR TITLE
FEAT: The enable cookies option for JavaScriptBuilderElement is now configurable per-request.

### DIFF
--- a/fiftyone_pipeline_core/src/fiftyone_pipeline_core/constants.py
+++ b/fiftyone_pipeline_core/src/fiftyone_pipeline_core/constants.py
@@ -1,0 +1,59 @@
+# *********************************************************************
+# This Original Work is copyright of 51 Degrees Mobile Experts Limited.
+# Copyright 2023 51 Degrees Mobile Experts Limited, Davidson House,
+# Forbury Square, Reading, Berkshire, United Kingdom RG1 3EU.
+#
+# This Original Work is licensed under the European Union Public Licence
+# (EUPL) v.1.2 and is subject to its terms as set out below.
+#
+# If a copy of the EUPL was not distributed with this file, You can obtain
+# one at https://opensource.org/licenses/EUPL-1.2.
+#
+# The "Compatible Licences" set out in the Appendix to the EUPL (as may be
+# amended by the European Commission) shall be deemed incompatible for
+# the purposes of the Work and the provisions of the compatibility
+# clause in Article 5 of the EUPL shall not apply.
+#
+# If using the Work as, or as part of, a network application, by
+# including the attribution notice(s) required under Article 5 of the EUPL
+# in the end user terms of the application under an appropriate heading,
+# such notice(s) shall fulfill the requirements of that article.
+# ********************************************************************* 
+
+class Constants():
+
+    """!
+    The string used to split evidence name parts
+    """
+    EVIDENCE_SEPARATOR = "."
+
+    """!
+    Used to prefix evidence that is obtained from HTTP headers 
+    """
+    EVIDENCE_HTTPHEADER_PREFIX = "header"
+
+    """!
+    Used to prefix evidence that is obtained from HTTP bookies 
+    """
+    EVIDENCE_COOKIE_PREFIX = "cookie"
+
+    """!
+    Used to prefix evidence that is obtained from an HTTP request"s
+    query string or is passed into the pipeline for off-line 
+    processing.
+    """
+    EVIDENCE_QUERY_PREFIX = "query"
+
+    """!
+    The suffix used when the JavaScriptBuilderElement
+    "enable cookies" parameter is supplied as evidence.
+    """
+    EVIDENCE_ENABLE_COOKIES_SUFFIX = "fod-js-enable-cookies"
+
+    """!
+    The complete key to be used when the 
+    JavaScriptBuilderElement "enable cookies" 
+    parameter is supplied as part of the query 
+    string.
+    """
+    EVIDENCE_ENABLE_COOKIES = EVIDENCE_QUERY_PREFIX + EVIDENCE_SEPARATOR + EVIDENCE_ENABLE_COOKIES_SUFFIX

--- a/fiftyone_pipeline_core/src/fiftyone_pipeline_core/javascriptbuilder.py
+++ b/fiftyone_pipeline_core/src/fiftyone_pipeline_core/javascriptbuilder.py
@@ -36,6 +36,7 @@ from jsmin import jsmin
 from .flowelement import FlowElement
 from .evidence_keyfilter import EvidenceKeyFilter
 from .elementdata_dictionary import ElementDataDictionary
+from .constants import Constants
 
 
 class JavaScriptBuilderEvidenceKeyFilter(EvidenceKeyFilter):
@@ -80,7 +81,11 @@ class JavascriptBuilderElement(FlowElement):
         * callback url. This can be overriden with header.host evidence.
         * @param {string} options.endpoint The endpoint of the client side
         * callback url
-        * @param {boolean} options.enable_cookies whether cookies should be enabled
+        * @param {boolean} options.enable_cookies Whether the client JavaScript
+        * stored results of client side processing in cookies. This can also 
+        * be set per request, using the "query.fod-js-enable-cookies" evidence key.
+        * For more details on personal data policy,
+        * see http://51degrees.com/terms/client-services-privacy-policy/
         * @param {boolean} options.minify Whether to minify the JavaScript
 
         """
@@ -166,6 +171,12 @@ class JavascriptBuilderElement(FlowElement):
         variables["_host"] = host
         variables["_protocol"] = protocol
 
+        enableCookiesVal = flowdata.evidence.get(Constants.EVIDENCE_ENABLE_COOKIES)
+        if enableCookiesVal:
+            variables["_enableCookies"] = enableCookiesVal.lower() == "true"
+
+        variables["_enableCookies"]
+
         query_params = self.get_evidence_key_filter().filter_evidence(flowdata.evidence.get_all())
         variables["_sessionId"] = query_params["query.session-id"] if "query.session-id" in query_params else None
         variables["_sequence"] = query_params["query.sequence"] if "query.sequence" in query_params else None
@@ -187,7 +198,7 @@ class JavascriptBuilderElement(FlowElement):
  
             for param, paramvalue in query_params.items():
 
-                paramkey = param.split(".")[1] 
+                paramkey = param.split(".")[1]
 
                 query[paramkey] = paramvalue
   


### PR DESCRIPTION
Adding the query parameter fod-js-enable-cookies will override the option supplied to the element at construction.

This PR closes #109