### PR TITLE
Add UTM parameters to 51degrees.com links

### DIFF
--- a/.github/workflows/utm-link-lint.yml
+++ b/.github/workflows/utm-link-lint.yml
@@ -1,0 +1,25 @@
+name: UTM link lint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  utm-link-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout common-ci
+        uses: actions/checkout@v4
+        with:
+          repository: 51Degrees/common-ci
+          path: utm-lint-common-ci
+
+      - name: Lint 51degrees.com links
+        shell: pwsh
+        run: ./utm-lint-common-ci/scripts/utm-lint.ps1 -RepoRoot .

--- a/ci/README.md
+++ b/ci/README.md
@@ -4,7 +4,7 @@ This API complies with the `common-ci` approach.
 The following secrets are required:
 * `ACCESS_TOKEN` - GitHub [access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#about-personal-access-tokens) for cloning repos, creating PRs, etc.
     * Example: `github_pat_l0ng_r4nd0m_s7r1ng`
-* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/4.4/_info__resource_keys.html) for integration tests
+* `SUPER_RESOURCE_KEY` - [resource key](https://51degrees.com/documentation/_info__resource_keys.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=ci-readme.md&utm_term=api-specific-ci-cd-approach) for integration tests
     * Example: `R4nd0m-S7r1ng`
 * `PYPI_TOKEN` - [PyPI token](https://pypi.org/help/#apitoken) for publishing packages
     * Example: `pypi-sUp3r-l0nG_r4nd0m-s7r1Ng`

--- a/fiftyone_pipeline_cloudrequestengine/readme.md
+++ b/fiftyone_pipeline_cloudrequestengine/readme.md
@@ -1,8 +1,8 @@
 # Cloud Request Engine
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "Data rewards the curious") **Python Pipeline Cloud Request Engine**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_cloudrequestengine-readme.md&utm_term=cloud-request-engine "Data rewards the curious") **Python Pipeline Cloud Request Engine**
 
-[Developer Documentation](https://51degrees.com/pipeline-python/index.html?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "Developer Documentation")
+[Developer Documentation](https://51degrees.com/pipeline-python/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_cloudrequestengine-readme.md&utm_term=cloud-request-engine "Developer Documentation")
 
 ## Introduction
 
@@ -16,7 +16,7 @@ The Pipeline is a generic web request intelligence and data processing solution 
 
 This package uses the `engines` class created by the `fiftyone-pipeline-engines`. It makes available:
 
-* A `Cloud Request Engine` which calls the 51Degrees cloud service to fetch properties and metadata about them based on a provided resource key. Get a resource key at https://configure.51degrees.com/
+* A `Cloud Request Engine` which calls the 51Degrees cloud service to fetch properties and metadata about them based on a provided resource key. Get a resource key at https://configure.51degrees.com/?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_cloudrequestengine-readme.md&utm_term=this-package-fiftyone_pipeline_cloudrequestengine
 * A `Cloud Engine` template which reads data from the Cloud Request Engine.
 
 It is used by the cloud versions of the following 51Degrees engines:

--- a/fiftyone_pipeline_cloudrequestengine/setup.py
+++ b/fiftyone_pipeline_cloudrequestengine/setup.py
@@ -42,7 +42,7 @@ setuptools.setup(
     version=read("version.txt"),
     author="51Degrees Engineering",
     author_email="engineering@51degrees.com",
-    url="https://51degrees.com/",
+    url="https://51degrees.com/?utm_source=pypi&utm_medium=package&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_cloudrequestengine-setup.py&utm_term=url",
     description=("This package contains a shared engine that is used to make requests to the 51Degrees cloud service on behalf of other data services such as device detection or location."),
     long_description=read("readme.md"),
     long_description_content_type='text/markdown',

--- a/fiftyone_pipeline_cloudrequestengine/src/fiftyone_pipeline_cloudrequestengine/clouddata.py
+++ b/fiftyone_pipeline_cloudrequestengine/src/fiftyone_pipeline_cloudrequestengine/clouddata.py
@@ -28,7 +28,7 @@ class OnPremiseMissingPropertyService(MissingPropertyService):
 
     def check(self, key, flow_element):
 
-        raise Exception("Property " + key + " not found in data for element " + flow_element.datakey + ". This is because your resource key does not include access to this property. Properties that are included for this key under device are " + ', '.join(list(flow_element.get_properties().keys())) + ". For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html")
+        raise Exception("Property " + key + " not found in data for element " + flow_element.datakey + ". This is because your resource key does not include access to this property. Properties that are included for this key under device are " + ', '.join(list(flow_element.get_properties().keys())) + ". For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=comment&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_cloudrequestengine-src-fiftyone_pipeline_cloudrequestengine-clouddata.py&utm_term=property-not-found")
 
 class CloudData(AspectDataDictionary):
 

--- a/fiftyone_pipeline_cloudrequestengine/src/fiftyone_pipeline_cloudrequestengine/cloudengine.py
+++ b/fiftyone_pipeline_cloudrequestengine/src/fiftyone_pipeline_cloudrequestengine/cloudengine.py
@@ -70,7 +70,7 @@ class CloudEngine(Engine):
         # Add properties from the CloudRequestEngine which should already have them
 
         if not self.datakey in pipeline.flow_elements_list["cloud"].flow_element_properties:
-            raise Exception("Your resource key does not include access to any properties under the engine with key " + self.datakey +  " that was added to the pipeline. For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html " + "Available engine data keys are: " + str([e for e in pipeline.flow_elements_list["cloud"].flow_element_properties]))
+            raise Exception("Your resource key does not include access to any properties under the engine with key " + self.datakey +  " that was added to the pipeline. For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=comment&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_cloudrequestengine-src-fiftyone_pipeline_cloudrequestengine-cloudengine.py&utm_term=engine-properties-not-accessible " + "Available engine data keys are: " + str([e for e in pipeline.flow_elements_list["cloud"].flow_element_properties]))
 
         self.properties = pipeline.flow_elements_list["cloud"].flow_element_properties[self.datakey]
 
@@ -92,7 +92,7 @@ class CloudEngine(Engine):
 
         """
 
-        raise Exception("Your resource key does not include access to any properties under " + element +  ". For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html " + "Available element data keys are: " + str([e for e in flowdata.pipeline.flow_elements_display_list]))
+        raise Exception("Your resource key does not include access to any properties under " + element +  ". For more details on resource keys, see our explainer: https://51degrees.com/documentation/_info__resource_keys.html?utm_source=code&utm_medium=comment&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_cloudrequestengine-src-fiftyone_pipeline_cloudrequestengine-cloudengine.py&utm_term=element-properties-not-accessible " + "Available element data keys are: " + str([e for e in flowdata.pipeline.flow_elements_display_list]))
 
 
     def process_internal(self, flowdata):

--- a/fiftyone_pipeline_core/readme.md
+++ b/fiftyone_pipeline_core/readme.md
@@ -1,8 +1,8 @@
 # Pipeline Core
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "Data rewards the curious") **Python Pipeline Core**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_core-readme.md&utm_term=pipeline-core "Data rewards the curious") **Python Pipeline Core**
 
-[Developer Documentation](https://51degrees.com/pipeline-python/index.html?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "Developer Documentation")
+[Developer Documentation](https://51degrees.com/pipeline-python/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_core-readme.md&utm_term=pipeline-core "Developer Documentation")
 
 ## Introduction
 

--- a/fiftyone_pipeline_core/setup.py
+++ b/fiftyone_pipeline_core/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     version=read("version.txt"),
     author="51Degrees Engineering",
     author_email="engineering@51degrees.com",
-    url="https://51degrees.com/",
+    url="https://51degrees.com/?utm_source=pypi&utm_medium=package&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_core-setup.py&utm_term=url",
     description=("This package defines the essential components of the 51Degrees Pipeline API such as flow elements, flow data and evidence. It also packages together JavaScript served by a pipeline and allows for client side requests for additional data populated by evidence from the client side."),
     long_description=read("readme.md"),
     long_description_content_type='text/markdown',

--- a/fiftyone_pipeline_core/src/fiftyone_pipeline_core/javascriptbuilder.py
+++ b/fiftyone_pipeline_core/src/fiftyone_pipeline_core/javascriptbuilder.py
@@ -85,7 +85,7 @@ class JavascriptBuilderElement(FlowElement):
         * stored results of client side processing in cookies. This can also 
         * be set per request, using the "query.fod-js-enable-cookies" evidence key.
         * For more details on personal data policy,
-        * see http://51degrees.com/terms/client-services-privacy-policy/
+        * see https://51degrees.com/terms/client-services-privacy-policy/?utm_source=code&utm_medium=comment&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_core-src-fiftyone_pipeline_core-javascriptbuilder.py&utm_term=init
         * @param {boolean} options.minify Whether to minify the JavaScript
 
         """

--- a/fiftyone_pipeline_engines/readme.md
+++ b/fiftyone_pipeline_engines/readme.md
@@ -1,8 +1,8 @@
 # Pipeline Engines
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "Data rewards the curious") **Python Pipeline Engines**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_engines-readme.md&utm_term=pipeline-engines "Data rewards the curious") **Python Pipeline Engines**
 
-[Developer Documentation](https://51degrees.com/pipeline-python/index.html?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "Developer Documentation")
+[Developer Documentation](https://51degrees.com/pipeline-python/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_engines-readme.md&utm_term=pipeline-engines "Developer Documentation")
 
 ## Introduction
 

--- a/fiftyone_pipeline_engines/setup.py
+++ b/fiftyone_pipeline_engines/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     version=read("version.txt"),
     author="51Degrees Engineering",
     author_email="engineering@51degrees.com",
-    url="https://51degrees.com/",
+    url="https://51degrees.com/?utm_source=pypi&utm_medium=package&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_engines-setup.py&utm_term=url",
     description=("This package extends the flow element class created by the fiftyone-pipeline-core package into a specialized type of flow element called an engine."),
     long_description=read("readme.md"),
     long_description_content_type='text/markdown',

--- a/fiftyone_pipeline_engines_fiftyone/readme.md
+++ b/fiftyone_pipeline_engines_fiftyone/readme.md
@@ -1,8 +1,8 @@
 # Pipeline Engines Fiftyone
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "Data rewards the curious") **Python Pipeline Engines**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_engines_fiftyone-readme.md&utm_term=pipeline-engines-fiftyone "Data rewards the curious") **Python Pipeline Engines**
 
-[Developer Documentation](https://51degrees.com/pipeline-python/index.html?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "Developer Documentation")
+[Developer Documentation](https://51degrees.com/pipeline-python/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_engines_fiftyone-readme.md&utm_term=pipeline-engines-fiftyone "Developer Documentation")
 
 ## Introduction
 

--- a/fiftyone_pipeline_engines_fiftyone/setup.py
+++ b/fiftyone_pipeline_engines_fiftyone/setup.py
@@ -40,7 +40,7 @@ setuptools.setup(
     version=read("version.txt"),
     author="51Degrees Engineering",
     author_email="engineering@51degrees.com",
-    url="https://51degrees.com/",
+    url="https://51degrees.com/?utm_source=pypi&utm_medium=package&utm_campaign=pipeline-python&utm_content=fiftyone_pipeline_engines_fiftyone-setup.py&utm_term=url",
     description=("The 51Degrees Pipeline API is a generic web request intelligence and data processing solution with the ability to add a range of 51Degrees and/or custom plug ins (Engines). It includes a ShareUsage engine that sends usage data to 51Degrees in zipped batches."),
     long_description=read("readme.md"),
     long_description_content_type='text/markdown',

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # 51Degrees Pipeline API
 
-![51Degrees](https://51degrees.com/DesktopModules/FiftyOne/Distributor/Logo.ashx?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "Data rewards the curious") **Python Pipeline**
+![51Degrees](https://51degrees.com/img/logo.png?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=readme.md&utm_term=51degrees-pipeline-api "Data rewards the curious") **Python Pipeline**
 
-[Developer Documentation](https://51degrees.com/pipeline-python/index.html?utm_source=github&utm_medium=repository&utm_content=readme_main&utm_campaign=python-open-source "Developer Documentation")
+[Developer Documentation](https://51degrees.com/pipeline-python/index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=readme.md&utm_term=51degrees-pipeline-api "Developer Documentation")
 
 ## Introduction
 This repository contains the components of the Python implementation of the 51Degrees Pipeline API.
@@ -18,8 +18,8 @@ This repository contains 3 modules:
 
 ## Dependencies
 
-For runtime dependencies, see our [dependencies](http://51degrees.com/documentation/_info__dependencies.html) page.
-The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html) page shows the Python versions that we currently test against. The software may run fine against other versions, but additional caution should be applied.
+For runtime dependencies, see our [dependencies](https://51degrees.com/documentation/_info__dependencies.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=readme.md&utm_term=dependencies) page.
+The [tested versions](https://51degrees.com/documentation/_info__tested_versions.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=readme.md&utm_term=dependencies) page shows the Python versions that we currently test against. The software may run fine against other versions, but additional caution should be applied.
 
 ## Installation
 
@@ -49,7 +49,7 @@ and examples that are available. To run tests:
 ## Examples
 
 There are several examples available that demonstrate how to make use of the Pipeline API in isolation. These are described in the table below.
-If you want examples that demonstrate how to use 51Degrees products such as device detection, then these are available in the corresponding [repository](https://github.com/51Degrees/device-detection-python) and on our [website](http://51degrees.com/documentation/_examples__device_detection__index.html).
+If you want examples that demonstrate how to use 51Degrees products such as device detection, then these are available in the corresponding [repository](https://github.com/51Degrees/device-detection-python) and on our [website](https://51degrees.com/documentation/_examples__device_detection__index.html?utm_source=github&utm_medium=readme&utm_campaign=pipeline-python&utm_content=readme.md&utm_term=examples).
 
 | Example                                                                     | Description                                                                                          |
 |-----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
## What

Tags navigational links to `51degrees.com` and `configure.51degrees.com` across all sub-packages with the standard UTM scheme so the Content Team can trace traffic to its exact source.

## Scheme

`?utm_source=<source>&utm_medium=<medium>&utm_campaign=pipeline-python&utm_content=<file-slug>&utm_term=<location>`

- **utm_source**: `github` for markdown rendered on github.com, `code` for library source comments and user-visible strings, `pypi` for package metadata fields.
- **utm_medium**: `readme` for README files, `comment` for library source comments and runtime messages, `package` for `setup.py` metadata.
- **utm_campaign**: `pipeline-python`.
- **utm_content**: the file path slug.
- **utm_term**: location within the file. For markdown the nearest heading, for source the enclosing function/class/member, and for runtime exception messages a message-meaning slug such as `property-not-found`, `engine-properties-not-accessible`, or `element-properties-not-accessible` so the clicked message can be identified.

Also normalises `http` to `https`, moves the retired `Logo.ashx` logo to `/img/logo.png`, replaces the old `*-open-source` query scheme, and un-versions an old `/documentation/4.4/` link. The configure share-key path is preserved with the query appended after it.

Functional endpoints (`cloud`, `devices-v4`) and test fixtures are deliberately left untouched.

## Lint

Adds `.github/workflows/utm-link-lint.yml`, which runs the shared `utm-lint.ps1` from `51Degrees/common-ci` on pull requests and pushes to keep these links conformant.