### PR TITLE
FIX: Copy the OWID in the FodId constructor, not just from_owid

### DIFF
--- a/fiftyone_pipeline_did/src/fiftyone_pipeline_did/fod_id.py
+++ b/fiftyone_pipeline_did/src/fiftyone_pipeline_did/fod_id.py
@@ -75,14 +75,20 @@ class FodId:
         """Promotes an already-parsed :class:`owid.Owid` into a 51Did by
         unpacking its payload.
 
-        Raises :class:`TypeError` if ``owid`` is ``None`` and
-        :class:`ValueError` if the payload is shorter than the minimum for its
-        identifier type.
+        The OWID is **copied** (round-tripped through its byte form), not
+        aliased, so a ``FodId`` can never desync from its envelope if the caller
+        later mutates the OWID they passed in. The OWID must therefore be signed
+        (serializable).
+
+        Raises :class:`TypeError` if ``owid`` is ``None``, :class:`ValueError`
+        if the payload is shorter than the minimum for its identifier type, and
+        :class:`owid.OwidError` if the OWID cannot be serialized (e.g. it is
+        unsigned).
         """
         if owid is None:
             raise TypeError("owid must not be None")
-        self._owid = owid
-        payload = owid.payload
+        self._owid = Owid.from_byte_array(owid.as_byte_array())
+        payload = self._owid.payload
         if payload is None or len(payload) < self.HEADER_LENGTH:
             raise ValueError(
                 "51Did payload must be at least {0} bytes; got {1}.".format(
@@ -144,15 +150,15 @@ class FodId:
     def from_owid(cls, owid: Owid) -> "FodId":
         """Promotes an already-parsed OWID into a 51Did.
 
-        The OWID is **copied** (round-tripped through its byte form), not
-        aliased, so a ``FodId`` can never desync from its envelope if the
-        caller later mutates the OWID it passed in. The supplied OWID must
-        therefore be signed (serializable). Raises :class:`TypeError` if
-        ``owid`` is ``None``.
+        The constructor **copies** the OWID (round-tripped through its byte
+        form), not aliases it, so a ``FodId`` can never desync from its
+        envelope if the caller later mutates the OWID it passed in. The
+        supplied OWID must therefore be signed (serializable). Raises
+        :class:`TypeError` if ``owid`` is ``None``.
         """
         if owid is None:
             raise TypeError("owid must not be None")
-        return cls(Owid.from_byte_array(owid.as_byte_array()))
+        return cls(owid)
 
     @property
     def flags(self) -> int:

--- a/fiftyone_pipeline_did/tests/test_fodid.py
+++ b/fiftyone_pipeline_did/tests/test_fodid.py
@@ -318,6 +318,16 @@ class FodIdTests(unittest.TestCase):
         self.assertEqual(CANONICAL_HASH, fod.hash)
         self.assertEqual(0x20, fod.payload[FodId.HASH_OFFSET])
 
+    def test_constructor_is_decoupled_from_source_owid(self):
+        # The constructor must copy the OWID too, not just from_owid -
+        # mutating the source afterwards must not affect the FodId.
+        owid = self.factory.signed_owid(canonical_payload())
+        fod = FodId(owid)
+        owid.payload = bytes(FodId.PAYLOAD_LENGTH)  # mutate the source
+        self.assertEqual(CANONICAL_FLAGS, fod.flags)
+        self.assertEqual(CANONICAL_HASH, fod.hash)
+        self.assertEqual(0x20, fod.payload[FodId.HASH_OFFSET])
+
     def test_verify_with_wrong_key_returns_false(self):
         fod = FodId.from_base64(
             self.factory.signed_owid_base64(canonical_payload()))


### PR DESCRIPTION
Follow-up to the 51Did reader ([#57](https://github.com/51Degrees/pipeline-python/pull/57)), addressing a review point from Eugene on the PHP port ([pipeline-php-did#2](https://github.com/51Degrees/pipeline-php-did/pull/2)) and propagating the fix for cross-port consistency (per the review guidelines).

## Problem

`FodId.from_owid` already copies the OWID, but the **public constructor** `FodId(owid)` still aliased the caller's instance (`self._owid = owid`). An `owid.Owid` is mutable, so `FodId(owid)` followed by mutating `owid` reintroduced exactly the cached-`hash` vs live-`payload` desync that `from_owid` was fixed to prevent. Java already avoids this (its constructor is private and `Owid` is `final`); Python and Node shared the gap.

## Fix

Copy the OWID in the constructor (round-trip through its byte form), so **every** construction path is decoupled from the caller's instance:

```python
self._owid = Owid.from_byte_array(owid.as_byte_array())
```

`from_owid` now simply delegates to the constructor (single copy site). The OWID must be signed (serializable), consistent with the existing `from_owid` contract.

## Test

Adds `test_constructor_is_decoupled_from_source_owid` (mirrors the existing `from_owid` decouple test, but via the public constructor). Full suite: **33/33 pass**.
